### PR TITLE
feat: add lobby live list template

### DIFF
--- a/apps/game-mate/src/config/libs.config.ts
+++ b/apps/game-mate/src/config/libs.config.ts
@@ -1,6 +1,7 @@
 import { LibReducerBase } from "@perfect-paradise/shared";
 import { exampleReducers } from "@perfect-paradise/game-mate/example";
+import { liveListReducers } from "@perfect-paradise/game-mate/live-list";
 
 export const libsReducers: LibReducerBase[] = [
-  exampleReducers,
+  exampleReducers, liveListReducers
 ];

--- a/libs/game-mate/live-list/.eslintrc.json
+++ b/libs/game-mate/live-list/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nx/react", "../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/game-mate/live-list/README.md
+++ b/libs/game-mate/live-list/README.md
@@ -1,0 +1,7 @@
+# game-mate-example
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test game-mate-example` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/game-mate/live-list/project.json
+++ b/libs/game-mate/live-list/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "game-mate-live-list",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/game-mate/live-list/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project game-mate-live-list --web",
+  "targets": {}
+}

--- a/libs/game-mate/live-list/src/index.ts
+++ b/libs/game-mate/live-list/src/index.ts
@@ -1,0 +1,14 @@
+import { LibReducerBase } from '@perfect-paradise/shared';
+import { liveListApi } from './lib/state/apiSlice';
+import { liveListReducer } from './lib/state/liveListSlice';
+
+export const liveListReducers: LibReducerBase = {
+  apis: {
+    [liveListApi.reducerPath]: liveListApi,
+  },
+  reducers: {
+    liveList: liveListReducer
+  }
+}
+
+export * from './lib/components/liveList';

--- a/libs/game-mate/live-list/src/lib/components/liveList.tsx
+++ b/libs/game-mate/live-list/src/lib/components/liveList.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useGetAllLiveItemsQuery } from "../state/apiSlice";
+import { appendLiveItems, selectLiveItems } from '../state/liveListSlice';
+
+export function LiveList(): JSX.Element {
+  const dispatch = useDispatch();
+  const items = useSelector(selectLiveItems);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const { data, refetch } = useGetAllLiveItemsQuery();
+
+  useEffect(() => {
+    if (data?.items) {
+      dispatch(appendLiveItems(data.items));
+    }
+  }, [data, dispatch]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            refetch();
+          }
+        });
+      },
+      { threshold: 1.0 }
+    );
+
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+
+    return () => {
+      if (observerRef.current) {
+        observer.unobserve(observerRef.current);
+      }
+    };
+  }, [refetch]);
+
+  return (
+    <div className="grid grid-cols-12 gap-4 border-2 rounded-md m-2 p-4 max-w-[350px]">
+      <div className="col-span-12 flex justify-center text-xl font-bold">Live Chat</div>
+      <div className="col-span-4">好友列表</div>
+      <div className="col-span-4 col-start-9">一些圖片</div>
+
+      <div className="col-span-12 h-[300px] overflow-y-auto">
+        {items.map((item, index) => (
+          <div key={index} className="col-span-12 grid grid-cols-12 gap-2">
+            <img
+              className="col-span-2 row-span-2 rounded-full w-10 h-10"
+              src={item.url}
+              alt={item.username}
+            />
+            <div className="col-span-10">
+              <div className="font-medium">{item.username}</div>
+              <div className="text-xs">{item.status_message}</div>
+            </div>
+          </div>
+        ))}
+        <div ref={observerRef} className="h-1"></div>
+      </div>
+    </div>
+  );
+}

--- a/libs/game-mate/live-list/src/lib/state/apiSlice.ts
+++ b/libs/game-mate/live-list/src/lib/state/apiSlice.ts
@@ -1,0 +1,25 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export interface LiveItem {
+  url: string;
+  username: string;
+  status_message: string;
+}
+
+export interface ApiResponse {
+  items: LiveItem[];
+}
+
+export const liveListApi = createApi({
+  reducerPath: 'liveListApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:5566/api/', // https://jsoneditoronline.org/#left=cloud.151b5373525244b9805afc307f047416
+  }),
+  endpoints: (builder) => ({
+    getAllLiveItems: builder.query<ApiResponse, void>({
+      query: () => `items`,
+    }),
+  }),
+});
+
+export const { useGetAllLiveItemsQuery } = liveListApi;

--- a/libs/game-mate/live-list/src/lib/state/liveListSlice.ts
+++ b/libs/game-mate/live-list/src/lib/state/liveListSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { LiveItem } from './apiSlice';
+
+interface LiveListState {
+  items: LiveItem[];
+}
+
+const initialState: LiveListState = {
+  items: [],
+};
+
+const liveListSlice = createSlice({
+  name: 'liveList',
+  initialState,
+  reducers: {
+    appendLiveItems: (state, action) => {
+      state.items = state.items.concat(action.payload);
+    },
+  },
+  selectors: {
+    selectLiveItems: (state) => state.items
+  },
+});
+
+export const { appendLiveItems } = liveListSlice.actions;
+export const { selectLiveItems } = liveListSlice.selectors;
+export const liveListReducer = liveListSlice.reducer;

--- a/libs/game-mate/live-list/tsconfig.json
+++ b/libs/game-mate/live-list/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json"
+}

--- a/libs/game-mate/live-list/tsconfig.lib.json
+++ b/libs/game-mate/live-list/tsconfig.lib.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts",
+      "next",
+      "@nx/next/typings/image.d.ts"
+    ]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.0.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-infinite-scroller": "^1.2.6",
         "react-redux": "^9.1.1",
         "tslib": "^2.3.0"
       },
@@ -13859,7 +13860,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15216,7 +15216,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15226,8 +15225,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -15439,6 +15437,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-infinite-scroller": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
+      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-infinite-scroller": "^1.2.6",
     "react-redux": "^9.1.1",
     "tslib": "^2.3.0"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,9 @@
       "@perfect-paradise/game-mate/example": [
         "libs/game-mate/example/src/index.ts"
       ],
+      "@perfect-paradise/game-mate/live-list": [
+        "libs/game-mate/live-list/src/index.ts"
+      ],
       "@perfect-paradise/shared": ["libs/shared/src/index.ts"]
     }
   },


### PR DESCRIPTION
此次變動：新增大廳的在線列表
說明：api 的部分是先用 node 起一個 server 回傳固定格式的假資料，格式都可以再調整

ps. redux 的部分不太熟悉，不確定這樣寫正不正確